### PR TITLE
Update main.js

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -207,10 +207,10 @@ class Fido2Lib {
         if (this.config.authenticatorAttachment !== undefined ||
             this.config.authenticatorRequireResidentKey !== undefined ||
             this.config.authenticatorUserVerification !== undefined) {
-            options.authenticatorSelectionCriteria = {};
-            setOpt(options.authenticatorSelectionCriteria, "attachment", this.config.authenticatorAttachment);
-            setOpt(options.authenticatorSelectionCriteria, "requireResidentKey", this.config.authenticatorRequireResidentKey);
-            setOpt(options.authenticatorSelectionCriteria, "userVerification", this.config.authenticatorUserVerification);
+            options.authenticatorSelection = {};
+            setOpt(options.authenticatorSelection, "authenticatorAttachment", this.config.authenticatorAttachment);
+            setOpt(options.authenticatorSelection, "requireResidentKey", this.config.authenticatorRequireResidentKey);
+            setOpt(options.authenticatorSelection, "userVerification", this.config.authenticatorUserVerification);
         }
         setOpt(options, "rawChallenge", rawChallenge);
 


### PR DESCRIPTION
Changed property _authenticatorSelectionCriteria_ into _authenticatorSelection_. The w3c writes _authenticatorSelection_ of type _AuthenticatorSelectionCriteria_ (https://www.w3.org/TR/webauthn/#dom-publickeycredentialcreationoptions-authenticatorselection)
_userVerification_ is now working, when set to "required" it enforces a PIN setup during attestation and  asks for a pin during assertion.
Changed wrong property _attachment_ into _authenticatorAttachment_. This is now also working for "platform" and "cross-platform" also tested and working now with both Solo & Yubi... well both devices are rejected when in "platform" mode and that's according to specs :-) since those two devices are roaming and not build in devices.